### PR TITLE
[💡FEATURE] JWT 인증 구현 및 스웨거 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,11 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,10 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
+    // Security
+    implementation("org.springframework.boot:spring-boot-starter-security")
+    testImplementation("org.springframework.security:spring-security-test")
 }
 
 tasks.named('test') {

--- a/src/main/java/org/example/backend/BackendApplication.java
+++ b/src/main/java/org/example/backend/BackendApplication.java
@@ -2,8 +2,10 @@ package org.example.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class BackendApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/org/example/backend/domain/test/TestController.java
+++ b/src/main/java/org/example/backend/domain/test/TestController.java
@@ -1,0 +1,38 @@
+package org.example.backend.domain.test;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.example.backend.global.auth.annotation.LoginUserId;
+import org.example.backend.global.common.exception.CustomException;
+import org.example.backend.global.common.response.BaseResponse;
+import org.example.backend.global.swagger.CustomExceptionDescription;
+import org.example.backend.global.swagger.SwaggerResponseDescription;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.example.backend.global.common.response.status.BaseExceptionResponseStatus.BAD_REQUEST;
+
+@Tag(name = "Test", description = "테스트 API")
+@RestController
+public class TestController {
+
+    @Operation(
+            summary = "테스트 API",
+            description = "로그인 사용자 id 및 권한 테스트용 API"
+    )
+    @CustomExceptionDescription(SwaggerResponseDescription.DEFAULT)
+    @GetMapping("/test")
+    public BaseResponse<String> test(@LoginUserId Long userId){
+        return new BaseResponse<>("userId is " + userId);
+    }
+
+    @Operation(
+            summary = "테스트 API",
+            description = "예외 테스트용 API"
+    )
+    @CustomExceptionDescription(SwaggerResponseDescription.DEFAULT)
+    @GetMapping("/exception")
+    public BaseResponse<Void> exception(){
+        throw new CustomException(BAD_REQUEST);
+    }
+}

--- a/src/main/java/org/example/backend/domain/users/model/Role.java
+++ b/src/main/java/org/example/backend/domain/users/model/Role.java
@@ -7,9 +7,16 @@ public enum Role {
 
     VOL("자원봉사자"), ORG("기관");
 
+    private static final String ROLE_PREFIX = "ROLE_";
+
     private final String value;
 
     Role(String value) {
         this.value = value;
+    }
+
+    /** Spring Security 권한 식별자 (hasRole/hasAuthority에서 사용하는 값) */
+    public String getAuthority() {
+        return ROLE_PREFIX + name();
     }
 }

--- a/src/main/java/org/example/backend/domain/users/model/Role.java
+++ b/src/main/java/org/example/backend/domain/users/model/Role.java
@@ -1,0 +1,15 @@
+package org.example.backend.domain.users.model;
+
+import lombok.Getter;
+
+@Getter
+public enum Role {
+
+    VOL("자원봉사자"), ORG("기관");
+
+    private final String value;
+
+    Role(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/org/example/backend/domain/users/model/User.java
+++ b/src/main/java/org/example/backend/domain/users/model/User.java
@@ -1,0 +1,27 @@
+package org.example.backend.domain.users.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.example.backend.global.common.model.BaseEntity;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+public class User extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+}

--- a/src/main/java/org/example/backend/domain/users/model/User.java
+++ b/src/main/java/org/example/backend/domain/users/model/User.java
@@ -12,11 +12,11 @@ import org.example.backend.global.common.model.BaseEntity;
 public class User extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id", nullable = false)
+    @Column(nullable = false)
     private Long id;
 
     @Column(nullable = false, unique = true)
-    private String email;
+    private String username;
 
     @Column(nullable = false)
     private String password;

--- a/src/main/java/org/example/backend/domain/users/repository/UserRepository.java
+++ b/src/main/java/org/example/backend/domain/users/repository/UserRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-    Optional<User> findByUsername(String username);
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/org/example/backend/domain/users/repository/UserRepository.java
+++ b/src/main/java/org/example/backend/domain/users/repository/UserRepository.java
@@ -2,9 +2,11 @@ package org.example.backend.domain.users.repository;
 
 import org.example.backend.domain.users.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
+@Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-    Optional<User> findByEmail(String email);
+    Optional<User> findByUsername(String username);
 }

--- a/src/main/java/org/example/backend/domain/users/repository/UserRepository.java
+++ b/src/main/java/org/example/backend/domain/users/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package org.example.backend.domain.users.repository;
+
+import org.example.backend.domain.users.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUsername(String username);
+}

--- a/src/main/java/org/example/backend/global/auth/annotation/LoginUserId.java
+++ b/src/main/java/org/example/backend/global/auth/annotation/LoginUserId.java
@@ -1,0 +1,11 @@
+package org.example.backend.global.auth.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginUserId {
+}

--- a/src/main/java/org/example/backend/global/auth/argument_resolver/LoginUserIdArgumentResolver.java
+++ b/src/main/java/org/example/backend/global/auth/argument_resolver/LoginUserIdArgumentResolver.java
@@ -1,0 +1,39 @@
+package org.example.backend.global.auth.argument_resolver;
+
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.backend.global.auth.annotation.LoginUserId;
+import org.example.backend.global.auth.util.JwtClaimKey;
+import org.example.backend.global.auth.util.JwtUtil;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import static org.example.backend.global.auth.constant.JwtAutenticationFilterConstants.TOKEN_FOR_ARGUMENT_RESOLVER;
+
+
+@Slf4j
+@RequiredArgsConstructor
+public class LoginUserIdArgumentResolver implements HandlerMethodArgumentResolver {
+    private final JwtUtil jwtUtil;
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(Long.class) && parameter.hasParameterAnnotation(LoginUserId.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        String token = (String) request.getAttribute(TOKEN_FOR_ARGUMENT_RESOLVER.getValue());
+        if(token == null) {
+            return 1L;
+        }
+        Long userId = jwtUtil.validateJwt(token).get(JwtClaimKey.USER_ID.getKey(), Long.class);
+        log.info("userId = {}",  userId);
+        return userId;
+    }
+}

--- a/src/main/java/org/example/backend/global/auth/constant/JwtAutenticationFilterConstants.java
+++ b/src/main/java/org/example/backend/global/auth/constant/JwtAutenticationFilterConstants.java
@@ -1,0 +1,18 @@
+package org.example.backend.global.auth.constant;
+
+public enum JwtAutenticationFilterConstants {
+    AUTHORIZATION("Authorization"),
+    TOKEN_PREFIX("Bearer "),
+    TOKEN_FOR_ARGUMENT_RESOLVER("token"),
+    JWT_ERROR_CODE("jwt_error_code");
+
+    private final String value;
+
+    private JwtAutenticationFilterConstants(String value){
+        this.value = value;
+    }
+
+    public String getValue(){
+        return this.value;
+    }
+}

--- a/src/main/java/org/example/backend/global/auth/constant/JwtErrorCode.java
+++ b/src/main/java/org/example/backend/global/auth/constant/JwtErrorCode.java
@@ -1,0 +1,5 @@
+package org.example.backend.global.auth.constant;
+
+public enum JwtErrorCode {
+    INVALID_JWT_ERROR, EXPIRED_JWT_ERROR, JWT_NOT_FOUND_ERROR;
+}

--- a/src/main/java/org/example/backend/global/auth/exception/InvalidJwtException.java
+++ b/src/main/java/org/example/backend/global/auth/exception/InvalidJwtException.java
@@ -1,0 +1,11 @@
+package org.example.backend.global.auth.exception;
+
+
+import org.example.backend.global.common.exception.CustomException;
+import org.example.backend.global.common.response.status.ResponseStatus;
+
+public class InvalidJwtException extends CustomException {
+    public InvalidJwtException(ResponseStatus exceptionStatus){
+        super(exceptionStatus);
+    }
+}

--- a/src/main/java/org/example/backend/global/auth/exception/JwtExpiredException.java
+++ b/src/main/java/org/example/backend/global/auth/exception/JwtExpiredException.java
@@ -1,0 +1,11 @@
+package org.example.backend.global.auth.exception;
+
+
+import org.example.backend.global.common.exception.CustomException;
+import org.example.backend.global.common.response.status.ResponseStatus;
+
+public class JwtExpiredException extends CustomException {
+    public JwtExpiredException(ResponseStatus exceptionStatus){
+        super(exceptionStatus);
+    }
+}

--- a/src/main/java/org/example/backend/global/auth/exception/JwtNotFoundException.java
+++ b/src/main/java/org/example/backend/global/auth/exception/JwtNotFoundException.java
@@ -1,0 +1,10 @@
+package org.example.backend.global.auth.exception;
+
+import org.example.backend.global.common.exception.CustomException;
+import org.example.backend.global.common.response.status.ResponseStatus;
+
+public class JwtNotFoundException extends CustomException {
+    public JwtNotFoundException(ResponseStatus exceptionStatus){
+        super(exceptionStatus);
+    }
+}

--- a/src/main/java/org/example/backend/global/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/example/backend/global/auth/filter/JwtAuthenticationFilter.java
@@ -19,6 +19,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -64,6 +65,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             catch(JwtNotFoundException e){
                 log.info("JWT claims string is empty.", e);
                 request.setAttribute(JWT_ERROR_CODE.getValue(), JwtErrorCode.JWT_NOT_FOUND_ERROR);
+            }
+            catch(UsernameNotFoundException e){
+                log.info("User not found for JWT subject/email.", e);
+                request.setAttribute(JWT_ERROR_CODE.getValue(), JwtErrorCode.INVALID_JWT_ERROR);
             }
         }
 

--- a/src/main/java/org/example/backend/global/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/example/backend/global/auth/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,85 @@
+package org.example.backend.global.auth.filter;
+
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.backend.global.auth.constant.JwtErrorCode;
+import org.example.backend.global.auth.exception.InvalidJwtException;
+import org.example.backend.global.auth.exception.JwtExpiredException;
+import org.example.backend.global.auth.exception.JwtNotFoundException;
+import org.example.backend.global.auth.security.CustomUserDetailsService;
+import org.example.backend.global.auth.util.JwtClaimKey;
+import org.example.backend.global.auth.util.JwtUtil;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+import static org.example.backend.global.auth.constant.JwtAutenticationFilterConstants.*;
+
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final JwtUtil jwtUtil;
+    private final CustomUserDetailsService customUserDetailsService;
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String token = resolveToken(request);
+        if(token != null){
+            try{
+                Claims claims = jwtUtil.validateJwt(token);
+
+                // UserDetails 생성
+                Long userId = claims.get(JwtClaimKey.USER_ID.getKey(), Long.class);
+
+                // userDetails 조회
+                UserDetails userDetails = customUserDetailsService.loadUserByUsername(String.valueOf(userId));
+
+                // 인증토큰을 생성하고 시큐리티 컨텍스트홀더에 저장
+                Authentication authToken = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                SecurityContextHolder.getContext().setAuthentication(authToken);
+
+                // token을 argument resolver에 전달
+                request.setAttribute(TOKEN_FOR_ARGUMENT_RESOLVER.getValue(), token);
+
+            }
+            // entryPoint에 전달할 에러 코드들
+            catch(InvalidJwtException e){
+                log.info("Invalid JWT Token", e);
+                request.setAttribute(JWT_ERROR_CODE.getValue(), JwtErrorCode.INVALID_JWT_ERROR);
+            }
+            catch(JwtExpiredException e){
+                log.info("Expired JWT Token", e);
+                request.setAttribute(JWT_ERROR_CODE.getValue(), JwtErrorCode.EXPIRED_JWT_ERROR);
+            }
+            catch(JwtNotFoundException e){
+                log.info("JWT claims string is empty.", e);
+                request.setAttribute(JWT_ERROR_CODE.getValue(), JwtErrorCode.JWT_NOT_FOUND_ERROR);
+            }
+        }
+
+        // 다음 필터로 진행
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request){
+        String authorization = request.getHeader(AUTHORIZATION.getValue());
+        if(authorization != null && authorization.startsWith(TOKEN_PREFIX.getValue())){
+            String token = authorization.split(" ")[1];
+            return token;
+        }
+        log.info("token does not exist!");
+        return null;
+    }
+}

--- a/src/main/java/org/example/backend/global/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/example/backend/global/auth/filter/JwtAuthenticationFilter.java
@@ -40,11 +40,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             try{
                 Claims claims = jwtUtil.validateJwt(token);
 
-                // UserDetails 생성
-                Long userId = claims.get(JwtClaimKey.USER_ID.getKey(), Long.class);
-
                 // userDetails 조회
-                UserDetails userDetails = customUserDetailsService.loadUserByUsername(String.valueOf(userId));
+                String email = claims.get(JwtClaimKey.EMAIL.getKey(), String.class);
+                UserDetails userDetails = customUserDetailsService.loadUserByUsername(email);
 
                 // 인증토큰을 생성하고 시큐리티 컨텍스트홀더에 저장
                 Authentication authToken = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());

--- a/src/main/java/org/example/backend/global/auth/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/org/example/backend/global/auth/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,31 @@
+package org.example.backend.global.auth.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.example.backend.global.common.response.BaseErrorResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+import static org.example.backend.global.common.response.status.BaseExceptionResponseStatus.FORBIDDEN;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    private final ObjectMapper objectMapper;
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+        BaseErrorResponse body =  new BaseErrorResponse(FORBIDDEN);
+        String json = objectMapper.writeValueAsString(body);
+
+        response.setStatus(FORBIDDEN.getCode());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("utf-8");
+        response.getWriter().write(json);
+    }
+}

--- a/src/main/java/org/example/backend/global/auth/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/org/example/backend/global/auth/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,64 @@
+package org.example.backend.global.auth.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.example.backend.global.auth.constant.JwtErrorCode;
+import org.example.backend.global.common.response.BaseErrorResponse;
+import org.example.backend.global.common.response.status.ResponseStatus;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+import java.io.IOException;
+
+import static org.example.backend.global.auth.constant.JwtAutenticationFilterConstants.JWT_ERROR_CODE;
+import static org.example.backend.global.common.response.status.BaseExceptionResponseStatus.*;
+
+
+@Slf4j
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final HandlerExceptionResolver resolver;
+    private final ObjectMapper objectMapper;
+
+    public CustomAuthenticationEntryPoint(@Qualifier("handlerExceptionResolver") HandlerExceptionResolver resolver, ObjectMapper objectMapper){
+        this.resolver = resolver;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException ex) throws IOException{
+        log.info("[commence] 인증 실패로 인증 실패 응답 발생 ");
+
+        JwtErrorCode errorCode = (JwtErrorCode) request.getAttribute(JWT_ERROR_CODE.getValue());
+
+        if(errorCode != null){
+            // JWT 예외 원인에 따라서 응답 세분화
+            log.info("[commence] Jwt 관련 Exception 발생! errorCode={}", errorCode);
+            switch (errorCode){
+                case INVALID_JWT_ERROR -> writeErrorResponse(response, INVALID_JWT);
+                case EXPIRED_JWT_ERROR -> writeErrorResponse(response, EXPIRED_JWT);
+                case JWT_NOT_FOUND_ERROR -> writeErrorResponse(response, JWT_NOT_FOUND);
+                default ->  writeErrorResponse(response, UNAUTHORIZED);
+            }
+        }
+        else{
+            writeErrorResponse(response, UNAUTHORIZED);
+        }
+    }
+
+    public void writeErrorResponse(HttpServletResponse response, ResponseStatus status) throws IOException{
+        BaseErrorResponse body =  new BaseErrorResponse(status);
+        String json = objectMapper.writeValueAsString(body);
+//        log.info("[commence] 응답 JSON = {}", json);
+        response.setStatus(status.getCode());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("utf-8");
+        response.getWriter().write(json);
+    }
+}

--- a/src/main/java/org/example/backend/global/auth/security/CustomUserDetails.java
+++ b/src/main/java/org/example/backend/global/auth/security/CustomUserDetails.java
@@ -1,0 +1,53 @@
+package org.example.backend.global.auth.security;
+
+import org.example.backend.domain.users.model.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+public class CustomUserDetails implements UserDetails {
+    private final User user;
+
+    public CustomUserDetails(User user) {
+        this.user = user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().getValue()));
+    }
+
+    @Override
+    public String getPassword() {
+        return "";
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/org/example/backend/global/auth/security/CustomUserDetails.java
+++ b/src/main/java/org/example/backend/global/auth/security/CustomUserDetails.java
@@ -27,7 +27,7 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public String getUsername() {
-        return user.getEmail();
+        return user.getUsername();
     }
 
     @Override

--- a/src/main/java/org/example/backend/global/auth/security/CustomUserDetails.java
+++ b/src/main/java/org/example/backend/global/auth/security/CustomUserDetails.java
@@ -17,7 +17,7 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().getValue()));
+        return List.of(new SimpleGrantedAuthority(user.getRole().getAuthority()));
     }
 
     @Override

--- a/src/main/java/org/example/backend/global/auth/security/CustomUserDetailsService.java
+++ b/src/main/java/org/example/backend/global/auth/security/CustomUserDetailsService.java
@@ -15,14 +15,14 @@ public class CustomUserDetailsService implements UserDetailsService {
     private final UserRepository userRepository;
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        return userRepository.findByUsername(username)
+        return userRepository.findByEmail(username)
                 .map(user ->{
                     log.info("[loadUserByUsername] User was found. user = {}",  user);
                     return new CustomUserDetails(user);
                 })
                 .orElseThrow(() -> {
                     log.info("[loadUserByUsername] User with email {} cannot found!!", username );
-                    throw new UsernameNotFoundException("User with email" + username + " cannot found!!");
+                    throw new UsernameNotFoundException("User with email " + username + " cannot found!!");
                 });
     }
 }

--- a/src/main/java/org/example/backend/global/auth/security/CustomUserDetailsService.java
+++ b/src/main/java/org/example/backend/global/auth/security/CustomUserDetailsService.java
@@ -15,14 +15,14 @@ public class CustomUserDetailsService implements UserDetailsService {
     private final UserRepository userRepository;
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        return userRepository.findByEmail(username)
+        return userRepository.findByUsername(username)
                 .map(user ->{
                     log.info("[loadUserByUsername] User was found. user = {}",  user);
                     return new CustomUserDetails(user);
                 })
                 .orElseThrow(() -> {
-                    log.info("[loadUserByUsername] User with email {} cannot found!!", username );
-                    throw new UsernameNotFoundException("User with email " + username + " cannot found!!");
+                    log.info("[loadUserByUsername] User with username {} cannot found!!", username );
+                    throw new UsernameNotFoundException("User with username " + username + " cannot found!!");
                 });
     }
 }

--- a/src/main/java/org/example/backend/global/auth/security/CustomUserDetailsService.java
+++ b/src/main/java/org/example/backend/global/auth/security/CustomUserDetailsService.java
@@ -1,0 +1,28 @@
+package org.example.backend.global.auth.security;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.backend.domain.users.repository.UserRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class CustomUserDetailsService implements UserDetailsService {
+    private final UserRepository userRepository;
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        return userRepository.findByUsername(username)
+                .map(user ->{
+                    log.info("[loadUserByUsername] User was found. user = {}",  user);
+                    return new CustomUserDetails(user);
+                })
+                .orElseThrow(() -> {
+                    log.info("[loadUserByUsername] User with email {} cannot found!!", username );
+                    throw new UsernameNotFoundException("User with email" + username + " cannot found!!");
+                });
+    }
+}

--- a/src/main/java/org/example/backend/global/auth/util/JwtClaimKey.java
+++ b/src/main/java/org/example/backend/global/auth/util/JwtClaimKey.java
@@ -2,6 +2,7 @@ package org.example.backend.global.auth.util;
 
 public enum JwtClaimKey {
     USER_ID("userId"),
+    EMAIL("email"),
     ROLE("role");
     private String key;
 

--- a/src/main/java/org/example/backend/global/auth/util/JwtClaimKey.java
+++ b/src/main/java/org/example/backend/global/auth/util/JwtClaimKey.java
@@ -1,0 +1,15 @@
+package org.example.backend.global.auth.util;
+
+public enum JwtClaimKey {
+    USER_ID("userId"),
+    ROLE("role");
+    private String key;
+
+    private JwtClaimKey(String key){
+        this.key = key;
+    }
+
+    public String getKey(){
+        return this.key;
+    }
+}

--- a/src/main/java/org/example/backend/global/auth/util/JwtUtil.java
+++ b/src/main/java/org/example/backend/global/auth/util/JwtUtil.java
@@ -3,7 +3,6 @@ package org.example.backend.global.auth.util;
 
 import io.jsonwebtoken.*;
 import lombok.extern.slf4j.Slf4j;
-import org.example.backend.domain.users.model.Role;
 import org.example.backend.global.auth.exception.InvalidJwtException;
 import org.example.backend.global.auth.exception.JwtExpiredException;
 import org.example.backend.global.auth.exception.JwtNotFoundException;
@@ -22,15 +21,16 @@ import static org.example.backend.global.common.response.status.BaseExceptionRes
 public class JwtUtil {
     private final SecretKey secretKey;
 
-    @Value("${onit.jwt.access.expire-ms}")
+    @Value("${secret.jwt-expired-in}")
     private long accessTokenExpireMs;
 
-    public JwtUtil(@Value("${onit.jwt.secret-key}") String secret) {
+    public JwtUtil(@Value("${secret.jwt-secret-key}") String secret) {
         secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
     }
 
-    public String createAccessToken(Long userId, Role role) {
+    public String createAccessToken(String email, Long userId) {
         return Jwts.builder()
+                .claim(JwtClaimKey.EMAIL.getKey(), email)
                 .claim(JwtClaimKey.USER_ID.getKey(), userId)
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + accessTokenExpireMs))

--- a/src/main/java/org/example/backend/global/auth/util/JwtUtil.java
+++ b/src/main/java/org/example/backend/global/auth/util/JwtUtil.java
@@ -48,6 +48,8 @@ public class JwtUtil {
             throw new JwtExpiredException(EXPIRED_JWT);
         } catch (UnsupportedJwtException e) {
             throw new InvalidJwtException(INVALID_JWT);
+        } catch (SecurityException | SignatureException e) {
+            throw new InvalidJwtException(INVALID_JWT);
         } catch (IllegalArgumentException e) {
             throw new JwtNotFoundException(JWT_NOT_FOUND);
         }

--- a/src/main/java/org/example/backend/global/auth/util/JwtUtil.java
+++ b/src/main/java/org/example/backend/global/auth/util/JwtUtil.java
@@ -1,0 +1,55 @@
+package org.example.backend.global.auth.util;
+
+
+import io.jsonwebtoken.*;
+import lombok.extern.slf4j.Slf4j;
+import org.example.backend.domain.users.model.Role;
+import org.example.backend.global.auth.exception.InvalidJwtException;
+import org.example.backend.global.auth.exception.JwtExpiredException;
+import org.example.backend.global.auth.exception.JwtNotFoundException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+import static org.example.backend.global.common.response.status.BaseExceptionResponseStatus.*;
+
+@Slf4j
+@Component
+public class JwtUtil {
+    private final SecretKey secretKey;
+
+    @Value("${onit.jwt.access.expire-ms}")
+    private long accessTokenExpireMs;
+
+    public JwtUtil(@Value("${onit.jwt.secret-key}") String secret) {
+        secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
+    }
+
+    public String createAccessToken(Long userId, Role role) {
+        return Jwts.builder()
+                .claim(JwtClaimKey.USER_ID.getKey(), userId)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + accessTokenExpireMs))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public Claims validateJwt(String token){
+        log.info("validateJwt");
+        try{
+            return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload();
+        } catch (MalformedJwtException e) {
+            throw new InvalidJwtException(INVALID_JWT);
+        } catch (ExpiredJwtException e) {
+            throw new JwtExpiredException(EXPIRED_JWT);
+        } catch (UnsupportedJwtException e) {
+            throw new InvalidJwtException(INVALID_JWT);
+        } catch (IllegalArgumentException e) {
+            throw new JwtNotFoundException(JWT_NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/org/example/backend/global/common/exception_handler/GlobalControllerAdvice.java
+++ b/src/main/java/org/example/backend/global/common/exception_handler/GlobalControllerAdvice.java
@@ -4,10 +4,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.example.backend.global.common.exception.CustomException;
 import org.example.backend.global.common.response.BaseErrorResponse;
 import org.hibernate.TypeMismatchException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.NoHandlerFoundException;
@@ -23,6 +26,7 @@ public class GlobalControllerAdvice {
      * 숫자/boolean 등의 타입이 일치하지 않는 경우 발생하는 Hibernate 예외 처리
      * 주로 잘못된 파라미터 변환 시 발생 (ex. boolean 필드에 문자열 전달)
      */
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(TypeMismatchException.class)
     public BaseErrorResponse handle_TypeMismatchException(TypeMismatchException e){
         log.error("[handle_TypeMismatchException]", e);
@@ -32,6 +36,7 @@ public class GlobalControllerAdvice {
     /**
      * 존재하지 않는 API 경로로 요청했을 때 발생 (404 Not Found)
      */
+    @ResponseStatus(HttpStatus.NOT_FOUND)
     @ExceptionHandler(NoHandlerFoundException.class)
     public BaseErrorResponse handle_NoHandlerFoundException(NoHandlerFoundException e){
         log.error("[handle_NoHandlerFoundException]", e);
@@ -42,6 +47,7 @@ public class GlobalControllerAdvice {
      * 처리되지 않은 런타임 예외를 전역적으로 처리
      * 서버 내부 오류(500 Internal Server Error) 응답 반환
      */
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(RuntimeException.class)
     public BaseErrorResponse handle_RuntimeException(RuntimeException e) {
         log.error("[handle_RuntimeException]", e);
@@ -52,6 +58,7 @@ public class GlobalControllerAdvice {
      * @Valid 또는 @Validated를 통해 DTO 필드 유효성 검사에 실패한 경우 처리
      * (e.g., 필수값 누락, 길이 초과 등)
      */
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public BaseErrorResponse handle_MethodArgumentNotValidException(MethodArgumentNotValidException e) {
         log.error("[handle_MethodArgumentNotValidException]", e);
@@ -64,6 +71,7 @@ public class GlobalControllerAdvice {
      * @RequestParam 필드가 아예 전달되지 않은 경우 처리
      * (e.g., 필수 쿼리 파라미터 누락)
      */
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(MissingServletRequestParameterException.class)
     public BaseErrorResponse handle_MissingServletRequestParameterException(MissingServletRequestParameterException e) {
         log.error("[handle_MissingServletRequestParameterException]", e);
@@ -75,6 +83,7 @@ public class GlobalControllerAdvice {
      * @RequestParam, @PathVariable 등에서 enum/숫자 등의 타입 변환이 실패한 경우 처리
      * (e.g., 잘못된 enum 값, 숫자 자리에 문자열 입력 등)
      */
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public BaseErrorResponse handleMethodArgumentTypeMismatch(MethodArgumentTypeMismatchException e) {
         log.error("[handleMethodArgumentTypeMismatch]", e);
@@ -91,8 +100,9 @@ public class GlobalControllerAdvice {
      * 각 예외가 담고 있는 커스텀 응답 코드와 메시지를 그대로 반환
      */
     @ExceptionHandler(CustomException.class)
-    public BaseErrorResponse handle_CustomException(CustomException e) {
+    public ResponseEntity<BaseErrorResponse> handle_CustomException(CustomException e) {
         log.error("[handle_CustomException]", e);
-        return new BaseErrorResponse(e.getExceptionStatus());
+        return ResponseEntity.status(e.getExceptionStatus().getStatus())
+                .body(new BaseErrorResponse(e.getExceptionStatus()));
     }
 }

--- a/src/main/java/org/example/backend/global/common/model/BaseEntity.java
+++ b/src/main/java/org/example/backend/global/common/model/BaseEntity.java
@@ -1,0 +1,28 @@
+package org.example.backend.global.common.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "CHAR(1)", nullable = false)
+    private BaseStatus status = BaseStatus.Y;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}
+

--- a/src/main/java/org/example/backend/global/common/model/BaseStatus.java
+++ b/src/main/java/org/example/backend/global/common/model/BaseStatus.java
@@ -1,0 +1,5 @@
+package org.example.backend.global.common.model;
+
+public enum BaseStatus {
+    Y, N
+}

--- a/src/main/java/org/example/backend/global/common/response/BaseErrorResponse.java
+++ b/src/main/java/org/example/backend/global/common/response/BaseErrorResponse.java
@@ -3,49 +3,57 @@ package org.example.backend.global.common.response;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import org.example.backend.global.common.response.status.ResponseStatus;
 
 import java.time.LocalDateTime;
 
 @Getter
-@JsonPropertyOrder({"success", "code", "message", "timestamp"})
+@JsonPropertyOrder({"status", "code", "message", "timestamp"})
 public class BaseErrorResponse implements ResponseStatus {
-    private final boolean success;
+    @Schema(example = "200")
+    private final int status;
+
+    @Schema(example = "200")
     private final int code;
+
+    @Schema(example = "요청에 성공하였습니다.")
     private final String message;
+
+    @Schema(example = "2025-01-01 00:00:00")
     private final LocalDateTime timestamp;
 
     @JsonCreator
     public BaseErrorResponse(
-            @JsonProperty("success") boolean success,
+            @JsonProperty("status") int status,
             @JsonProperty("code") int code,
             @JsonProperty("message") String message,
             @JsonProperty("timestamp") LocalDateTime timestamp
     ) {
-        this.success = success;
+        this.status = status;
         this.code = code;
         this.message = message;
         this.timestamp = timestamp;
     }
 
     public BaseErrorResponse(ResponseStatus status) {
-        this.success = false;
+        this.status = status.getStatus();
         this.code = status.getCode();
         this.message = status.getMessage();
         this.timestamp = LocalDateTime.now();
     }
 
     public BaseErrorResponse(ResponseStatus status, String message) {
-        this.success = false;
+        this.status = status.getStatus();
         this.code = status.getCode();
         this.message = message;
         this.timestamp = LocalDateTime.now();
     }
 
     @Override
-    public boolean getSuccess() {
-        return this.success;
+    public int getStatus() {
+        return this.status;
     }
     @Override
     public int getCode() {

--- a/src/main/java/org/example/backend/global/common/response/BaseResponse.java
+++ b/src/main/java/org/example/backend/global/common/response/BaseResponse.java
@@ -4,31 +4,34 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import org.example.backend.global.common.response.status.ResponseStatus;
+import org.springframework.http.HttpStatus;
 
 import static org.example.backend.global.common.response.status.BaseExceptionResponseStatus.SUCCESS;
 
 @Getter
-@JsonPropertyOrder({"success", "code", "message", "data"})
+@JsonPropertyOrder({"status", "code", "message", "data"})
 public class BaseResponse<T> implements ResponseStatus {
-    private final boolean success;
+    @Schema(example = "200")
+    private final int status;
 
     @Schema(example = "200")
     private final int code;
 
     @Schema(example = "요청에 성공하였습니다.")
     private final String message;
+
     private final T data;
 
     public BaseResponse(T data) {
-        this.success = true;
+        this.status = HttpStatus.OK.value();
         this.code = SUCCESS.getCode();
         this.message = SUCCESS.getMessage();
         this.data = data;
     }
 
     @Override
-    public boolean getSuccess() {
-        return this.success;
+    public int getStatus(){
+        return this.status;
     }
     @Override
     public int getCode() {

--- a/src/main/java/org/example/backend/global/common/response/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/org/example/backend/global/common/response/status/BaseExceptionResponseStatus.java
@@ -1,31 +1,36 @@
 package org.example.backend.global.common.response.status;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor
 public enum BaseExceptionResponseStatus implements ResponseStatus{
     // 성공
-    SUCCESS(200, "요청에 성공했습니다."),
+    SUCCESS(HttpStatus.OK.value(), 200, "요청에 성공했습니다."),
 
     // 공통 에러
-    BAD_REQUEST(400, "유효하지 않은 요청입니다."),
-    UNAUTHORIZED(401, "인증 자격이 없습니다."),
-    FORBIDDEN(403, "권한이 없습니다."),
-    API_NOT_FOUND(404, "존재하지 않는 API입니다."),
-    METHOD_NOT_ALLOWED(405, "유효하지 않은 Http 메서드입니다."),
-    INTERNAL_SERVER_ERROR(500, "서버 내부 오류입니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST.value(),400, "유효하지 않은 요청입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED.value(), 401, "인증 자격이 없습니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN.value(), 403, "권한이 없습니다."),
+    API_NOT_FOUND(HttpStatus.NOT_FOUND.value(),404, "존재하지 않는 API입니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED.value(), 405, "유효하지 않은 Http 메서드입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), 500, "서버 내부 오류입니다."),
 
     // JWT 토큰
-    INVALID_JWT(401, "올바르지 않은 토큰입니다."),
-    EXPIRED_JWT(401, "만료된 토큰입니다"),
-    JWT_NOT_FOUND(400, "토큰을 찾을 수 없습니다");
+    INVALID_JWT(HttpStatus.UNAUTHORIZED.value(), 401, "올바르지 않은 토큰입니다."),
+    EXPIRED_JWT(HttpStatus.UNAUTHORIZED.value(), 401, "만료된 토큰입니다"),
+    JWT_NOT_FOUND(HttpStatus.UNAUTHORIZED.value(), 400, "토큰을 찾을 수 없습니다");
 
-    private final boolean success = false;
+
+    private final int status;
     private final int code;
     private final String message;
 
+
     @Override
-    public boolean getSuccess() { return this.success; }
+    public int getStatus() {
+        return this.status;
+    }
 
     @Override
     public int getCode() {

--- a/src/main/java/org/example/backend/global/common/response/status/ResponseStatus.java
+++ b/src/main/java/org/example/backend/global/common/response/status/ResponseStatus.java
@@ -1,7 +1,7 @@
 package org.example.backend.global.common.response.status;
 
 public interface ResponseStatus {
-    boolean getSuccess();
+    int getStatus();
 
     int getCode();
 

--- a/src/main/java/org/example/backend/global/config/SecurityConfig.java
+++ b/src/main/java/org/example/backend/global/config/SecurityConfig.java
@@ -1,0 +1,63 @@
+package org.example.backend.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.example.backend.global.auth.filter.JwtAuthenticationFilter;
+import org.example.backend.global.auth.security.CustomAuthenticationEntryPoint;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final String[] PERMIT_URL = {
+            "/swagger-ui/**", "/api-docs", "/swagger-ui-custom.html",
+            "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html", "/swagger-ui/index.html",
+    };
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception{
+
+        http
+                .csrf((auth) -> auth.disable());
+
+        http
+                .formLogin((auth)->auth.disable());
+
+        http
+                .httpBasic((auth)->auth.disable());
+
+        // 토큰 기반 인증 비활성화
+        http
+                .authorizeHttpRequests((auth)-> auth
+                        .anyRequest().permitAll());
+
+        // 토큰 기반 인증 활성화
+//        http
+//                .authorizeHttpRequests((auth)-> auth
+//                        .requestMatchers(PERMIT_URL).permitAll()
+//                        .anyRequest().authenticated());
+
+        // 토큰 검증 필터 추가
+        http
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        // 토큰 검증 예외 처리 추가
+        http
+                .exceptionHandling(configurer -> configurer.authenticationEntryPoint(customAuthenticationEntryPoint));
+
+        http
+                .sessionManagement((session)->session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        return http.build();
+    }
+}

--- a/src/main/java/org/example/backend/global/config/SecurityConfig.java
+++ b/src/main/java/org/example/backend/global/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package org.example.backend.global.config;
 
 import lombok.RequiredArgsConstructor;
 import org.example.backend.global.auth.filter.JwtAuthenticationFilter;
+import org.example.backend.global.auth.security.CustomAccessDeniedHandler;
 import org.example.backend.global.auth.security.CustomAuthenticationEntryPoint;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -18,6 +19,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
     private final String[] PERMIT_URL = {
             "/swagger-ui/**", "/api-docs", "/swagger-ui-custom.html",
             "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html", "/swagger-ui/index.html",
@@ -44,6 +46,7 @@ public class SecurityConfig {
 //        http
 //                .authorizeHttpRequests((auth)-> auth
 //                        .requestMatchers(PERMIT_URL).permitAll()
+//                        .requestMatchers("test").hasRole("ORG")
 //                        .anyRequest().authenticated());
 
         // 토큰 검증 필터 추가
@@ -52,7 +55,9 @@ public class SecurityConfig {
 
         // 토큰 검증 예외 처리 추가
         http
-                .exceptionHandling(configurer -> configurer.authenticationEntryPoint(customAuthenticationEntryPoint));
+                .exceptionHandling(
+                        configurer -> configurer.authenticationEntryPoint(customAuthenticationEntryPoint)
+                                        .accessDeniedHandler(customAccessDeniedHandler));
 
         http
                 .sessionManagement((session)->session

--- a/src/main/java/org/example/backend/global/config/SwaggerConfig.java
+++ b/src/main/java/org/example/backend/global/config/SwaggerConfig.java
@@ -1,0 +1,110 @@
+package org.example.backend.global.config;
+
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import org.example.backend.global.common.response.BaseErrorResponse;
+import org.example.backend.global.common.response.status.BaseExceptionResponseStatus;
+import org.example.backend.global.swagger.CustomExceptionDescription;
+import org.example.backend.global.swagger.ExampleHolder;
+import org.example.backend.global.swagger.SwaggerResponseDescription;
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.HandlerMethod;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.stream.Collectors.groupingBy;
+
+@OpenAPIDefinition(
+        info = @Info(
+                title = "온잇 API 명세서",
+                description = "Springdoc을 이용한 Swagger API 문서입니다.",
+                version = "1.0"
+        )
+)
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI();
+    }
+
+    @Bean
+    public OperationCustomizer customize() {
+        return (Operation operation, HandlerMethod handlerMethod) -> {
+
+            CustomExceptionDescription customExceptionDescription = handlerMethod.getMethodAnnotation(
+                    CustomExceptionDescription.class);
+
+            // CustomExceptionDescription 어노테이션 단 메소드 적용
+            if (customExceptionDescription != null) {
+                generateErrorCodeResponseExample(operation, customExceptionDescription.value());
+            }
+
+            return operation;
+        };
+    }
+
+    private void generateErrorCodeResponseExample(
+            Operation operation, SwaggerResponseDescription type) {
+
+        ApiResponses responses = operation.getResponses();
+
+        Set<BaseExceptionResponseStatus> baseExceptionResponseStatusSet = type.getExceptionResponseStatusSet();
+
+        Map<Integer, List<ExampleHolder>> statusWithExampleHolders =
+                baseExceptionResponseStatusSet.stream()
+                        .map(
+                                baseExceptionResponseStatus -> {
+                                    return ExampleHolder.builder()
+                                            .holder(
+                                                    getSwaggerExample(baseExceptionResponseStatus))
+                                            .code(baseExceptionResponseStatus.getCode())
+                                            .name(baseExceptionResponseStatus.toString())
+                                            .build();
+                                }
+                        ).collect(groupingBy(ExampleHolder::getCode));
+        addExamplesToResponses(responses, statusWithExampleHolders);
+    }
+
+    private Example getSwaggerExample(BaseExceptionResponseStatus status) {
+        Example example = new Example();
+
+        BaseErrorResponse errorResponse = new BaseErrorResponse(status);
+        example.setValue(errorResponse);
+        example.description(status.getMessage());
+
+        return example;
+    }
+
+    private void addExamplesToResponses(
+            ApiResponses responses, Map<Integer, List<ExampleHolder>> statusWithExampleHolders) {
+        statusWithExampleHolders.forEach(
+                (status, v) -> {
+                    Content content = new Content();
+                    MediaType mediaType = new MediaType();
+                    ApiResponse apiResponse = new ApiResponse();
+                    v.forEach(
+                            exampleHolder -> {
+                                mediaType.addExamples(
+                                        exampleHolder.getName(), exampleHolder.getHolder());
+                            });
+                    content.addMediaType("application/json", mediaType);
+                    apiResponse.setDescription("");
+                    apiResponse.setContent(content);
+                    responses.addApiResponse(status.toString(), apiResponse);
+                });
+    }
+}

--- a/src/main/java/org/example/backend/global/config/WebConfig.java
+++ b/src/main/java/org/example/backend/global/config/WebConfig.java
@@ -1,0 +1,21 @@
+package org.example.backend.global.config;
+
+
+import lombok.RequiredArgsConstructor;
+import org.example.backend.global.auth.argument_resolver.LoginUserIdArgumentResolver;
+import org.example.backend.global.auth.util.JwtUtil;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+    private final JwtUtil jwtUtil;
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new LoginUserIdArgumentResolver(jwtUtil));
+    }
+}

--- a/src/main/java/org/example/backend/global/swagger/CustomExceptionDescription.java
+++ b/src/main/java/org/example/backend/global/swagger/CustomExceptionDescription.java
@@ -1,0 +1,13 @@
+package org.example.backend.global.swagger;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CustomExceptionDescription {
+
+    SwaggerResponseDescription value();
+}

--- a/src/main/java/org/example/backend/global/swagger/ExampleHolder.java
+++ b/src/main/java/org/example/backend/global/swagger/ExampleHolder.java
@@ -1,0 +1,14 @@
+package org.example.backend.global.swagger;
+
+import io.swagger.v3.oas.models.examples.Example;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ExampleHolder {
+
+    private Example holder;
+    private String name;
+    private int code;
+}

--- a/src/main/java/org/example/backend/global/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/org/example/backend/global/swagger/SwaggerResponseDescription.java
@@ -1,0 +1,32 @@
+package org.example.backend.global.swagger;
+
+import lombok.Getter;
+import org.example.backend.global.common.response.status.BaseExceptionResponseStatus;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static org.example.backend.global.common.response.status.BaseExceptionResponseStatus.*;
+
+
+@Getter
+public enum SwaggerResponseDescription {
+
+    DEFAULT(new LinkedHashSet<>());
+
+
+    private final Set<BaseExceptionResponseStatus> exceptionResponseStatusSet;
+
+    SwaggerResponseDescription(Set<BaseExceptionResponseStatus> exceptionResponseStatusSet) {
+        exceptionResponseStatusSet.addAll(new LinkedHashSet<>(Set.of(
+                BAD_REQUEST,
+                UNAUTHORIZED,
+                FORBIDDEN,
+                API_NOT_FOUND,
+                METHOD_NOT_ALLOWED,
+                INTERNAL_SERVER_ERROR
+        )));
+
+        this.exceptionResponseStatusSet = exceptionResponseStatusSet;
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈

#6 
#8 

## ✨ 구현 내용

- 스프링 시큐리티를 이용해서 JWT 기반 인증을 구현했습니다.
- 스프링 시큐리티 기능 특성상 User가 필요하여서 User 엔티티도 구현했습니다.
- 스웨거에 가능한 에러 예시를 모두 보여줄 수 있도록 설정을 추가했습니다.
- 스웨거 에러 예시 표시 방법은 다음과 같습니다.
1. SwaggerResponseDescription enum에 상수를 추가합니다. 상수 값에는 API에서 발생할 수 있는 예외를 추가하면 됩니다.
2. 컨트롤러 메서드에 CustomExceptionDescription 어노테이션을 추가합니다. 어노테이션에는 위의 enum 상수를 인자로 주면 됩니다. 
- 공통 응답의 상태 코드 수정

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - JWT 기반 인증 흐름(토큰 필터, 인증 실패/인가 거부 처리, 사용자 상세 로딩) 추가.
  - 사용자 도메인(역할·계정) 및 컨트롤러에서 로그인 사용자 ID 주입 기능 제공.
  - JPA 감사로 생성/수정 시각 등 공통 감사 필드 자동 관리.
  - API 응답 포맷 변경: 기존 성공 플래그 대신 정수형 status 필드로 응답 상태 표기(호환 주의).
- 문서
  - Swagger/OpenAPI에 표준 오류 응답 예시 자동 추가로 문서 가독성 향상.
- 작업
  - JWT 및 Spring Security 관련 의존성 추가, 보안·웹 설정 구성.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->