### PR TITLE
[💡FEATURE] 봉사자 메인 화면 조회 & 코드 등록 api #30

### DIFF
--- a/src/main/java/org/example/backend/domain/matching/model/Matching.java
+++ b/src/main/java/org/example/backend/domain/matching/model/Matching.java
@@ -9,6 +9,7 @@ import org.example.backend.global.common.model.BaseEntity;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 @Entity
 public class Matching extends BaseEntity {
     @Id

--- a/src/main/java/org/example/backend/domain/matching/model/Matching.java
+++ b/src/main/java/org/example/backend/domain/matching/model/Matching.java
@@ -29,28 +29,9 @@ public class Matching extends BaseEntity {
     @JoinColumn(name = "volunteer_id")
     private Volunteer volunteer;
 
-    public void updateMatchingStatus(MatchingStatus matchingStatus) {
-        this.matchingStatus = matchingStatus;
-    }
 
     public void updateVolunteer(Volunteer volunteer) {
         this.volunteer = volunteer;
     }
 
-    // 정적 팩토리 메소드들
-    public static Matching createForSenior(Senior senior) {
-        Matching matching = new Matching();
-        matching.senior = senior;
-        matching.matchingStatus = MatchingStatus.ACTIVE;
-        matching.volunteer = null;
-        return matching;
-    }
-
-    public static Matching createWithVolunteer(Senior senior, Volunteer volunteer) {
-        Matching matching = new Matching();
-        matching.senior = senior;
-        matching.volunteer = volunteer;
-        matching.matchingStatus = MatchingStatus.ACTIVE;
-        return matching;
-    }
 }

--- a/src/main/java/org/example/backend/domain/matching/model/Matching.java
+++ b/src/main/java/org/example/backend/domain/matching/model/Matching.java
@@ -7,7 +7,6 @@ import org.example.backend.domain.volunteer.model.Volunteer;
 import org.example.backend.global.common.model.BaseEntity;
 
 @Getter
-@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
@@ -18,7 +17,6 @@ public class Matching extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    @Builder.Default
     private MatchingStatus matchingStatus = MatchingStatus.ACTIVE;
 
     @ManyToOne
@@ -28,4 +26,29 @@ public class Matching extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "volunteer_id")
     private Volunteer volunteer;
+
+    public void updateMatchingStatus(MatchingStatus matchingStatus) {
+        this.matchingStatus = matchingStatus;
+    }
+
+    public void updateVolunteer(Volunteer volunteer) {
+        this.volunteer = volunteer;
+    }
+
+    // 정적 팩토리 메소드들
+    public static Matching createForSenior(Senior senior) {
+        Matching matching = new Matching();
+        matching.senior = senior;
+        matching.matchingStatus = MatchingStatus.ACTIVE;
+        matching.volunteer = null;
+        return matching;
+    }
+
+    public static Matching createWithVolunteer(Senior senior, Volunteer volunteer) {
+        Matching matching = new Matching();
+        matching.senior = senior;
+        matching.volunteer = volunteer;
+        matching.matchingStatus = MatchingStatus.ACTIVE;
+        return matching;
+    }
 }

--- a/src/main/java/org/example/backend/domain/matching/model/Matching.java
+++ b/src/main/java/org/example/backend/domain/matching/model/Matching.java
@@ -18,7 +18,8 @@ public class Matching extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private MatchingStatus matchingStatus = MatchingStatus.ACTIVE;
+    @Builder.Default
+    private MatchingStatus matchingStatus = MatchingStatus.PENDING;
 
     @ManyToOne
     @JoinColumn(name = "senior_id", nullable = false)

--- a/src/main/java/org/example/backend/domain/matching/repository/MatchingRepository.java
+++ b/src/main/java/org/example/backend/domain/matching/repository/MatchingRepository.java
@@ -17,4 +17,6 @@ public interface MatchingRepository extends JpaRepository<Matching, Long> {
     List<Matching> findAllByVolunteer(Volunteer volunteer);
 
     List<Matching> findAllBySeniorAndMatchingStatus(Senior senior, MatchingStatus matchingStatus);
+    
+    Optional<Matching> findBySeniorAndMatchingStatus(Senior senior, MatchingStatus matchingStatus);
 }

--- a/src/main/java/org/example/backend/domain/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/org/example/backend/domain/schedule/repository/ScheduleRepository.java
@@ -9,5 +9,6 @@ import java.util.Optional;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     Optional<Schedule> findByMatching(Matching matching);
+    List<Schedule> findAllByMatching(Matching matching);
     List<Schedule> findAllByMatchingIn(List<Matching> matchings);
 }

--- a/src/main/java/org/example/backend/domain/senior/repository/SeniorRepository.java
+++ b/src/main/java/org/example/backend/domain/senior/repository/SeniorRepository.java
@@ -6,9 +6,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface SeniorRepository extends JpaRepository<Senior, Long> {
     List<Senior> findAllByOrganization(Organization organization);
+
+    Optional<Senior> findByCode(String code);
     boolean existsByCode(String code);
 }

--- a/src/main/java/org/example/backend/domain/volunteer/controller/VolunteerController.java
+++ b/src/main/java/org/example/backend/domain/volunteer/controller/VolunteerController.java
@@ -5,10 +5,15 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.example.backend.domain.volunteer.dto.GetVolunteerMainResponse;
 import org.example.backend.domain.volunteer.dto.GetVolunteerMeResponse;
 import org.example.backend.domain.volunteer.dto.PatchVolunteerMeRequest;
+import org.example.backend.domain.volunteer.dto.RegisterCodeRequest;
+import org.example.backend.domain.volunteer.dto.RegisterCodeResponse;
 import org.example.backend.domain.volunteer.dto.RegisterVolunteerRequest;
 import org.example.backend.domain.volunteer.service.RegisterVolunteerService;
+import org.example.backend.domain.volunteer.service.VolunteerCodeService;
+import org.example.backend.domain.volunteer.service.VolunteerMainService;
 import org.example.backend.domain.volunteer.service.VolunteerMeService;
 import org.example.backend.global.auth.annotation.LoginUserId;
 import org.example.backend.global.common.response.BaseResponse;
@@ -29,6 +34,8 @@ import static org.example.backend.global.swagger.SwaggerResponseDescription.REGI
 public class VolunteerController {
     private final RegisterVolunteerService registerVolunteerService;
     private final VolunteerMeService volunteerMeService;
+    private final VolunteerMainService volunteerMainService;
+    private final VolunteerCodeService volunteerCodeService;
 
     @Operation(
             summary = "봉사자 회원가입 API",
@@ -64,5 +71,25 @@ public class VolunteerController {
         return new BaseResponse<>(null);
     }
 
+    @Operation(
+            summary = "봉사자 메인 화면 조회",
+            description = "봉사자의 메인 화면에 표시할 어르신 정보와 스케줄을 조회하는 API"
+    )
+    @CustomExceptionDescription(DEFAULT)
+    @GetMapping("main")
+    public BaseResponse<GetVolunteerMainResponse> getVolunteerMain(@LoginUserId @Parameter(hidden = true) Long loginUserId) {
+        return new BaseResponse<>(volunteerMainService.getMain(loginUserId));
+    }
 
+    @Operation(
+            summary = "봉사자 코드 등록",
+            description = "봉사자가 어르신과 매칭하기 위해 코드를 등록하는 API"
+    )
+    @CustomExceptionDescription(DEFAULT)
+    @PostMapping("codes")
+    public BaseResponse<RegisterCodeResponse> registerCode(
+            @LoginUserId @Parameter(hidden = true) Long loginUserId,
+            @RequestBody @jakarta.validation.Valid RegisterCodeRequest request) {
+        return new BaseResponse<>(volunteerCodeService.registerCode(loginUserId, request.code()));
+    }
 }

--- a/src/main/java/org/example/backend/domain/volunteer/dto/GetVolunteerMainResponse.java
+++ b/src/main/java/org/example/backend/domain/volunteer/dto/GetVolunteerMainResponse.java
@@ -35,6 +35,7 @@ public record GetVolunteerMainResponse(
 
             @Schema(description = "다음 일정", example = "2025-08-27")
             @JsonFormat(pattern = "yyyy-MM-dd")
+            @com.fasterxml.jackson.annotation.JsonProperty("next_schedule")
             LocalDate nextSchedule
     ) {}
 

--- a/src/main/java/org/example/backend/domain/volunteer/dto/RegisterCodeRequest.java
+++ b/src/main/java/org/example/backend/domain/volunteer/dto/RegisterCodeRequest.java
@@ -1,0 +1,11 @@
+package org.example.backend.domain.volunteer.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "코드 등록 요청")
+public record RegisterCodeRequest(
+        @Schema(description = "발급받은 코드", example = "254565")
+        @NotNull(message = "코드는 필수입니다")
+        String code
+) {}

--- a/src/main/java/org/example/backend/domain/volunteer/dto/RegisterCodeResponse.java
+++ b/src/main/java/org/example/backend/domain/volunteer/dto/RegisterCodeResponse.java
@@ -1,0 +1,40 @@
+package org.example.backend.domain.volunteer.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+@Builder
+@Schema(name = "RegisterCodeResponse", description = "코드 등록 응답")
+public record RegisterCodeResponse(
+        @Schema(description = "어르신 성함", example = "김순자")
+        String name,
+
+        @ArraySchema(arraySchema = @Schema(description = "스케줄 목록"), minItems = 0)
+        List<ScheduleDto> schedule,
+
+        @Schema(description = "특이사항", example = "당뇨, 보조기 사용")
+        String notes,
+
+        @Schema(description = "다음 일정", example = "2025-08-27")
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        @JsonProperty("next_schedule")
+        LocalDate nextSchedule
+) {
+    @Builder
+    @Schema(name = "Schedule", description = "스케줄 정보")
+    public record ScheduleDto(
+            @Schema(description = "요일", example = "Tuesday")
+            String day,
+
+            @Schema(description = "시간", example = "19:00")
+            @JsonFormat(pattern = "HH:mm")
+            LocalTime time
+    ) {}
+}

--- a/src/main/java/org/example/backend/domain/volunteer/service/VolunteerCodeService.java
+++ b/src/main/java/org/example/backend/domain/volunteer/service/VolunteerCodeService.java
@@ -90,15 +90,17 @@ public class VolunteerCodeService {
         Map<Long, List<ScheduleDetail>> scheduleToDetails = allScheduleDetails.stream()
                 .collect(Collectors.groupingBy(sd -> sd.getSchedule().getId()));
 
-        // 스케줄 정보 구성
+        // 스케줄 정보 구성 - 모든 스케줄의 상세 정보 수집
         List<RegisterCodeResponse.ScheduleDto> scheduleDtos = List.of();
         LocalDate nextSchedule = null;
 
         if (!schedules.isEmpty()) {
-            Schedule schedule = schedules.get(0); // 첫 번째 스케줄 사용
-            List<ScheduleDetail> details = scheduleToDetails.getOrDefault(schedule.getId(), List.of());
+            // 모든 스케줄의 상세 정보를 하나의 리스트로 수집
+            List<ScheduleDetail> allDetails = schedules.stream()
+                    .flatMap(schedule -> scheduleToDetails.getOrDefault(schedule.getId(), List.of()).stream())
+                    .toList();
             
-            scheduleDtos = details.stream()
+            scheduleDtos = allDetails.stream()
                     .map(detail -> RegisterCodeResponse.ScheduleDto.builder()
                             .day(convertDayToString(detail.getDay()))
                             .time(detail.getStartTime())
@@ -106,7 +108,7 @@ public class VolunteerCodeService {
                     .toList();
 
             // 다음 일정 계산
-            nextSchedule = calculateNextSchedule(details);
+            nextSchedule = calculateNextSchedule(allDetails);
         }
 
         return RegisterCodeResponse.builder()

--- a/src/main/java/org/example/backend/domain/volunteer/service/VolunteerCodeService.java
+++ b/src/main/java/org/example/backend/domain/volunteer/service/VolunteerCodeService.java
@@ -1,0 +1,170 @@
+package org.example.backend.domain.volunteer.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.backend.domain.matching.model.Matching;
+import org.example.backend.domain.matching.model.MatchingStatus;
+import org.example.backend.domain.matching.repository.MatchingRepository;
+import org.example.backend.domain.schedule.model.Day;
+import org.example.backend.domain.schedule.model.Schedule;
+import org.example.backend.domain.schedule.model.ScheduleDetail;
+import org.example.backend.domain.schedule.repository.ScheduleDetailRepository;
+import org.example.backend.domain.schedule.repository.ScheduleRepository;
+import org.example.backend.domain.senior.model.Senior;
+import org.example.backend.domain.senior.repository.SeniorRepository;
+import org.example.backend.domain.users.model.User;
+import org.example.backend.domain.users.repository.UserRepository;
+import org.example.backend.domain.volunteer.dto.RegisterCodeResponse;
+import org.example.backend.domain.volunteer.model.Volunteer;
+import org.example.backend.domain.volunteer.repository.VolunteerRepository;
+import org.example.backend.global.common.exception.CustomException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.example.backend.global.common.response.status.BaseExceptionResponseStatus.BAD_REQUEST;
+import static org.example.backend.global.common.response.status.BaseExceptionResponseStatus.ENTITY_NOT_FOUND;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class VolunteerCodeService {
+    private final UserRepository userRepository;
+    private final VolunteerRepository volunteerRepository;
+    private final SeniorRepository seniorRepository;
+    private final MatchingRepository matchingRepository;
+    private final ScheduleRepository scheduleRepository;
+    private final ScheduleDetailRepository scheduleDetailRepository;
+
+    @Transactional
+    public RegisterCodeResponse registerCode(Long loginUserId, String code) {
+        log.info("코드 등록 시도 - userId: {}, code: {}", loginUserId, code);
+
+        // 봉사자 정보 조회
+        User user = userRepository.findById(loginUserId).orElseThrow(() -> new CustomException(BAD_REQUEST));
+        Volunteer volunteer = volunteerRepository.findByUser(user).orElseThrow(() -> new CustomException(BAD_REQUEST));
+
+        // 코드로 어르신 조회
+        Senior senior = seniorRepository.findByCode(code).orElseThrow(() -> new CustomException(ENTITY_NOT_FOUND));
+        log.info("어르신 발견 - seniorId: {}, name: {}", senior.getId(), senior.getName());
+
+        // 어르신의 기존 매칭 조회 (PENDING 상태의 매칭)
+        Matching existingMatching = matchingRepository.findBySeniorIdAndMatchingStatus(senior.getId(), MatchingStatus.PENDING)
+                .orElseThrow(() -> new CustomException(ENTITY_NOT_FOUND));
+        
+        // 이미 다른 봉사자가 매칭되어 있는지 확인
+        if (existingMatching.getVolunteer() != null) {
+            log.warn("이미 다른 봉사자가 매칭된 어르신입니다 - seniorId: {}, volunteerId: {}", 
+                    senior.getId(), existingMatching.getVolunteer().getId());
+            throw new CustomException(BAD_REQUEST);
+        }
+
+        // 기존 매칭에 봉사자 정보 업데이트
+        existingMatching.updateVolunteer(volunteer);
+        Matching updatedMatching = matchingRepository.save(existingMatching);
+        log.info("기존 매칭에 봉사자 정보 업데이트 - matchingId: {}, volunteerId: {}", 
+                updatedMatching.getId(), volunteer.getId());
+
+        // 어르신 정보와 스케줄 조회하여 응답 생성
+        return createResponse(senior);
+    }
+
+    private RegisterCodeResponse createResponse(Senior senior) {
+        // 어르신의 매칭 조회 (PENDING 상태의 매칭)
+        Matching matching = matchingRepository.findBySeniorAndMatchingStatus(senior, MatchingStatus.PENDING)
+                .orElse(null);
+        
+        if (matching == null) {
+            log.warn("어르신의 PENDING 매칭을 찾을 수 없음 - seniorId: {}", senior.getId());
+            throw new CustomException(ENTITY_NOT_FOUND);
+        }
+
+        // 스케줄 정보 조회
+        List<Schedule> schedules = scheduleRepository.findAllByMatching(matching);
+        List<ScheduleDetail> allScheduleDetails = scheduleDetailRepository.findAllByScheduleIn(schedules);
+        Map<Long, List<ScheduleDetail>> scheduleToDetails = allScheduleDetails.stream()
+                .collect(Collectors.groupingBy(sd -> sd.getSchedule().getId()));
+
+        // 스케줄 정보 구성
+        List<RegisterCodeResponse.ScheduleDto> scheduleDtos = List.of();
+        LocalDate nextSchedule = null;
+
+        if (!schedules.isEmpty()) {
+            Schedule schedule = schedules.get(0); // 첫 번째 스케줄 사용
+            List<ScheduleDetail> details = scheduleToDetails.getOrDefault(schedule.getId(), List.of());
+            
+            scheduleDtos = details.stream()
+                    .map(detail -> RegisterCodeResponse.ScheduleDto.builder()
+                            .day(convertDayToString(detail.getDay()))
+                            .time(detail.getStartTime())
+                            .build())
+                    .toList();
+
+            // 다음 일정 계산
+            nextSchedule = calculateNextSchedule(details);
+        }
+
+        return RegisterCodeResponse.builder()
+                .name(senior.getName())
+                .schedule(scheduleDtos)
+                .notes(senior.getNotes())
+                .nextSchedule(nextSchedule)
+                .build();
+    }
+
+    private String convertDayToString(Day day) {
+        return switch (day) {
+            case SUN -> "Sunday";
+            case MON -> "Monday";
+            case TUE -> "Tuesday";
+            case WED -> "Wednesday";
+            case THU -> "Thursday";
+            case FRI -> "Friday";
+            case SAT -> "Saturday";
+        };
+    }
+
+    private LocalDate calculateNextSchedule(List<ScheduleDetail> scheduleDetails) {
+        if (scheduleDetails.isEmpty()) {
+            return null;
+        }
+
+        LocalDate today = LocalDate.now();
+        LocalDate nextDate = null;
+
+        // 각 요일에 대해 다음 발생 날짜 계산
+        for (ScheduleDetail detail : scheduleDetails) {
+            DayOfWeek targetDay = convertDayToDayOfWeek(detail.getDay());
+            LocalDate candidateDate = today;
+
+            // 다음 해당 요일 찾기
+            while (candidateDate.getDayOfWeek() != targetDay || candidateDate.equals(today)) {
+                candidateDate = candidateDate.plusDays(1);
+            }
+
+            // 가장 가까운 날짜 선택
+            if (nextDate == null || candidateDate.isBefore(nextDate)) {
+                nextDate = candidateDate;
+            }
+        }
+
+        return nextDate;
+    }
+
+    private DayOfWeek convertDayToDayOfWeek(Day day) {
+        return switch (day) {
+            case SUN -> DayOfWeek.SUNDAY;
+            case MON -> DayOfWeek.MONDAY;
+            case TUE -> DayOfWeek.TUESDAY;
+            case WED -> DayOfWeek.WEDNESDAY;
+            case THU -> DayOfWeek.THURSDAY;
+            case FRI -> DayOfWeek.FRIDAY;
+            case SAT -> DayOfWeek.SATURDAY;
+        };
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
#30 


## ✨ 구현 내용
- 봉사자 메인 화면 조회 api
- 코드 등록 api

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 자원봉사자 메인 화면 조회 API 추가.
  - 매칭 코드 등록 API 추가: 발급 코드로 시니어와 연결하고 이름, 비고, 일정, 다음 일정 정보를 반환.

- **Improvements**
  - 동일 매칭에 대한 다중 일정 조회 지원 추가로 빈 결과를 리스트로 처리.
  - 응답 필드 명명 규칙 정비(예: next_schedule) 및 일정 응답 구조(시간/요일) 확장.
  - 매칭 연결 처리 흐름 개선으로 코드 등록 시 자원봉사자 연결이 반영됨.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->