### PR TITLE
[💡FEATURE] 기록 수정 화면 조회 api 에 어르신 이름 추가 & 기록작성 HTTP 메서드 POST로 변경 #41

### DIFF
--- a/src/main/java/org/example/backend/domain/volunteer/controller/VolunteerRecordController.java
+++ b/src/main/java/org/example/backend/domain/volunteer/controller/VolunteerRecordController.java
@@ -33,7 +33,7 @@ public class VolunteerRecordController {
     public BaseResponse<GetVolunteerRecordResponse> getRecords(@LoginUserId @Parameter(hidden = true) Long loginUserId) {
         return new BaseResponse<>(volunteerRecordService.getRecords(loginUserId));
     }
-    @PatchMapping
+    @PostMapping
     public BaseResponse<Void> setRecord(
             @LoginUserId @Parameter(hidden = true) Long loginUserId,
             @RequestBody @Valid PostVolunteerRecordRequest request

--- a/src/main/java/org/example/backend/domain/volunteer/dto/GetVolunteerRecordUpdateFormResponse.java
+++ b/src/main/java/org/example/backend/domain/volunteer/dto/GetVolunteerRecordUpdateFormResponse.java
@@ -19,6 +19,9 @@ import java.util.List;
 @Builder
 @Schema(name = "GetVolunteerRecordUpdateFormResponse", description = "봉사 기록 수정 폼 응답")
 public record GetVolunteerRecordUpdateFormResponse(
+        @Schema(description = "어르신 성함", example = "김순자")
+        String name,
+
         @ArraySchema(arraySchema = @Schema(description = "통화 기록 목록"), minItems = 0)
         List<CallHistoryDto> callHistory,
 

--- a/src/main/java/org/example/backend/domain/volunteer/service/VolunteerRecordService.java
+++ b/src/main/java/org/example/backend/domain/volunteer/service/VolunteerRecordService.java
@@ -199,11 +199,15 @@ public class VolunteerRecordService {
             throw new CustomException(BAD_REQUEST);
         }
 
+        // 어르신 정보 조회
+        Senior senior = record.getMatching().getSenior();
+        
         // 리포트 및 콜히스토리 조회
         Report report = record.getReport();
         List<CallHistory> callHistories = callHistoryRepository.findAllByVolunteerRecordOrderByStartTimeAsc(record);
 
         return GetVolunteerRecordUpdateFormResponse.builder()
+                .name(senior.getName())
                 .callHistory(callHistories.stream()
                         .map(ch -> GetVolunteerRecordUpdateFormResponse.CallHistoryDto.builder()
                                 .dateTime(ch.getStartTime())


### PR DESCRIPTION
## 📌 관련 이슈
#41 

## ✨ 구현 내용
- 기록 수정 화면 조회 api 에 어르신 이름 추가
- 기록작성 HTTP 메서드 POST로 변경

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 봉사 기록 수정 폼 응답에 어르신 성함 항목이 추가되어 폼에서 성함을 확인할 수 있습니다.
  - 봉사 기록 저장 요청이 POST 방식으로 제공되어 호출 방식이 간소화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->