### PR TITLE
[💡FEATURE] 어르신 등록 화면 조회 API 및 어르신 관리 화면 조회 API 구현

### DIFF
--- a/src/main/java/org/example/backend/domain/matching/repository/MatchingRepository.java
+++ b/src/main/java/org/example/backend/domain/matching/repository/MatchingRepository.java
@@ -19,4 +19,6 @@ public interface MatchingRepository extends JpaRepository<Matching, Long> {
     List<Matching> findAllBySeniorAndMatchingStatus(Senior senior, MatchingStatus matchingStatus);
     
     Optional<Matching> findBySeniorAndMatchingStatus(Senior senior, MatchingStatus matchingStatus);
+
+    Optional<Matching> findTopBySeniorOrderByIdDesc(Senior senior);
 }

--- a/src/main/java/org/example/backend/domain/matching/repository/MatchingRepository.java
+++ b/src/main/java/org/example/backend/domain/matching/repository/MatchingRepository.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface MatchingRepository extends JpaRepository<Matching, Long> {
-    Optional<Matching> findBySeniorIdAndMatchingStatus(Long seniorId, MatchingStatus matchingStatus);
+    Optional<Matching> findTopBySeniorIdAndMatchingStatus(Long seniorId, MatchingStatus matchingStatus);
 
     Optional<Matching> findByVolunteerIdAndSeniorIdAndMatchingStatus(Long volunteerId, Long seniorId, MatchingStatus status);
 

--- a/src/main/java/org/example/backend/domain/matching/repository/MatchingRepository.java
+++ b/src/main/java/org/example/backend/domain/matching/repository/MatchingRepository.java
@@ -10,6 +10,8 @@ import java.util.List;
 import java.util.Optional;
 
 public interface MatchingRepository extends JpaRepository<Matching, Long> {
+    Optional<Matching> findBySeniorIdAndMatchingStatus(Long seniorId, MatchingStatus matchingStatus);
+
     Optional<Matching> findTopBySeniorIdAndMatchingStatus(Long seniorId, MatchingStatus matchingStatus);
 
     Optional<Matching> findByVolunteerIdAndSeniorIdAndMatchingStatus(Long volunteerId, Long seniorId, MatchingStatus status);

--- a/src/main/java/org/example/backend/domain/organization/controller/OrganizationController.java
+++ b/src/main/java/org/example/backend/domain/organization/controller/OrganizationController.java
@@ -82,9 +82,19 @@ public class OrganizationController {
             description = "어르신 등록 화면을 조회하는 API"
     )
     @CustomExceptionDescription(MAIN)
-    @Parameter(in = ParameterIn.HEADER, required = true, name = "Authorization", description = "API 엑세스 토큰", example = "Bearer asdf1234")
     @GetMapping("/me/seniors")
     public BaseResponse<GetOrgSeniorsResponse> getOrgSeniors(@Parameter(hidden = true) @LoginUserId Long orgUserId){
         return new BaseResponse(getOrgSeniorsService.getSeniors(orgUserId));
+    }
+
+    @Operation(
+            summary = "기관 어르신 관리 화면 조회",
+            description = "어르신 관리 화면을 조회하는 API"
+    )
+    @CustomExceptionDescription(MAIN)
+    @GetMapping("/me/seniors/{seniorId}")
+    public BaseResponse<GetSeniorManagePageResponse> getSeniorManagementPage(@Parameter(hidden = true) @LoginUserId Long orgUserId,
+                                                                             @PathVariable Long seniorId){
+        return new BaseResponse<>(getOrgSeniorsService.getSenior(orgUserId, seniorId));
     }
 }

--- a/src/main/java/org/example/backend/domain/organization/controller/OrganizationController.java
+++ b/src/main/java/org/example/backend/domain/organization/controller/OrganizationController.java
@@ -77,8 +77,14 @@ public class OrganizationController {
         return new BaseResponse<>(organizationMainService.getMain(userId));
     }
 
+    @Operation(
+            summary = "기관 어르신 등록 화면 조회",
+            description = "어르신 등록 화면을 조회하는 API"
+    )
+    @CustomExceptionDescription(MAIN)
+    @Parameter(in = ParameterIn.HEADER, required = true, name = "Authorization", description = "API 엑세스 토큰", example = "Bearer asdf1234")
     @GetMapping("/me/seniors")
-    public BaseResponse<GetOrgSeniorsResponse> getOrgSeniors(@LoginUserId Long orgUserId){
+    public BaseResponse<GetOrgSeniorsResponse> getOrgSeniors(@Parameter(hidden = true) @LoginUserId Long orgUserId){
         return new BaseResponse(getOrgSeniorsService.getSeniors(orgUserId));
     }
 }

--- a/src/main/java/org/example/backend/domain/organization/controller/OrganizationController.java
+++ b/src/main/java/org/example/backend/domain/organization/controller/OrganizationController.java
@@ -6,10 +6,8 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.example.backend.domain.organization.dto.GetOrganizationMeResponse;
-import org.example.backend.domain.organization.dto.PatchOrganizationMeRequest;
-import org.example.backend.domain.organization.dto.GetOrganziationMainResponse;
-import org.example.backend.domain.organization.dto.RegisterOrganizationRequest;
+import org.example.backend.domain.organization.dto.*;
+import org.example.backend.domain.organization.service.GetOrgSeniorsService;
 import org.example.backend.domain.organization.service.OrganizationMeService;
 import org.example.backend.domain.organization.service.OrganizationMainService;
 import org.example.backend.domain.organization.service.RegisterOrganizationService;
@@ -32,6 +30,7 @@ public class OrganizationController {
     private final RegisterOrganizationService registerOrganizationService;
     private final OrganizationMeService organizationMeService;
     private final OrganizationMainService organizationMainService;
+    private final GetOrgSeniorsService getOrgSeniorsService;
 
     @Operation(
             summary = "기관 회원가입 API",
@@ -76,5 +75,10 @@ public class OrganizationController {
     @GetMapping("/main")
     public BaseResponse<GetOrganziationMainResponse> getMain(@Parameter(hidden = true) @LoginUserId Long userId){
         return new BaseResponse<>(organizationMainService.getMain(userId));
+    }
+
+    @GetMapping("/me/seniors")
+    public BaseResponse<GetOrgSeniorsResponse> getOrgSeniors(@LoginUserId Long orgUserId){
+        return new BaseResponse(getOrgSeniorsService.getSeniors(orgUserId));
     }
 }

--- a/src/main/java/org/example/backend/domain/organization/dto/GetOrgSeniorsResponse.java
+++ b/src/main/java/org/example/backend/domain/organization/dto/GetOrgSeniorsResponse.java
@@ -1,0 +1,27 @@
+package org.example.backend.domain.organization.dto;
+
+import org.example.backend.domain.matching.model.MatchingStatus;
+import org.example.backend.domain.senior.model.Senior;
+import org.example.backend.global.util.AgeUtils;
+
+import java.util.List;
+
+public record GetOrgSeniorsResponse (
+    List<SeniorDto> seniors
+){
+    public record SeniorDto(
+            Long seniorId,
+            String name,
+            Integer age,
+            String code,
+            String matchingStatus
+    ){
+        public static SeniorDto entityToDto(Senior entity, MatchingStatus matchingStatus) {
+            return new SeniorDto(entity.getId(),
+                    entity.getName(),
+                    AgeUtils.toAge(entity.getBirthday()),
+                    entity.getCode(),
+                    matchingStatus.name());
+        }
+    }
+}

--- a/src/main/java/org/example/backend/domain/organization/dto/GetSeniorManagePageResponse.java
+++ b/src/main/java/org/example/backend/domain/organization/dto/GetSeniorManagePageResponse.java
@@ -1,0 +1,20 @@
+package org.example.backend.domain.organization.dto;
+
+public record GetSeniorManagePageResponse(
+        SeniorProfile seniorProfile,
+        String seniorCode,
+        MatchedVolunteer matchedVolunteer
+) {
+    public record SeniorProfile(
+            String name,       // 성함
+            String birthday,   // 생년월일
+            String contact,    // 연락처
+            String startDate,  // 봉사 시작 날짜
+            String endDate     // 봉사 종료 날짜
+    ) {}
+
+    public record MatchedVolunteer(
+            String name,       // 봉사자 이름
+            String lastWorkDay // 봉사자 최근 활동
+    ) {}
+}

--- a/src/main/java/org/example/backend/domain/organization/service/GetOrgSeniorsService.java
+++ b/src/main/java/org/example/backend/domain/organization/service/GetOrgSeniorsService.java
@@ -1,14 +1,23 @@
 package org.example.backend.domain.organization.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.example.backend.domain.matching.model.Matching;
+import org.example.backend.domain.matching.model.MatchingStatus;
 import org.example.backend.domain.matching.repository.MatchingRepository;
 import org.example.backend.domain.organization.dto.GetOrgSeniorsResponse;
+import org.example.backend.domain.organization.dto.GetSeniorManagePageResponse;
 import org.example.backend.domain.organization.model.Organization;
 import org.example.backend.domain.organization.repository.OrganizationRepository;
+import org.example.backend.domain.record.model.VolunteerRecord;
+import org.example.backend.domain.record.repository.VolunteerRecordRepository;
+import org.example.backend.domain.schedule.model.Schedule;
+import org.example.backend.domain.schedule.repository.ScheduleRepository;
 import org.example.backend.domain.senior.model.Senior;
 import org.example.backend.domain.senior.repository.SeniorRepository;
+import org.example.backend.domain.volunteer.model.Volunteer;
 import org.example.backend.global.common.exception.CustomException;
+import org.example.backend.global.util.LocalDateTimeUtil;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -17,13 +26,19 @@ import java.util.stream.Collectors;
 
 import static org.example.backend.global.common.response.status.BaseExceptionResponseStatus.ENTITY_NOT_FOUND;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class GetOrgSeniorsService {
     private final OrganizationRepository organizationRepository;
     private final SeniorRepository seniorRepository;
     private final MatchingRepository matchingRepository;
+    private final ScheduleRepository scheduleRepository;
+    private final VolunteerRecordRepository volunteerRecordRepository;
+
     public GetOrgSeniorsResponse getSeniors(Long orgUserId) {
+        log.info("orgUserId = {}", orgUserId);
+
         // 기관 조회
         Organization organization = organizationRepository.findByUserId(orgUserId).orElseThrow(() -> new CustomException(ENTITY_NOT_FOUND));
 
@@ -38,5 +53,44 @@ public class GetOrgSeniorsService {
         }).collect(Collectors.toList());
 
         return new GetOrgSeniorsResponse(collect);
+    }
+
+
+    public GetSeniorManagePageResponse getSenior(Long orgUserId, Long seniorId) {
+        log.info("orgUserId = {} seniorId = {}", orgUserId, seniorId);
+
+        // 기관 조회
+        Organization organization = organizationRepository.findByUserId(orgUserId).orElseThrow(() -> new CustomException(ENTITY_NOT_FOUND));
+
+        // 어르신을 찾고
+        Senior senior = seniorRepository.findById(seniorId).orElseThrow(() -> new CustomException(ENTITY_NOT_FOUND));
+        if(!senior.getOrganization().equals(organization)){
+            throw new CustomException(ENTITY_NOT_FOUND);
+        }
+
+        // 매칭을 찾고
+        Matching matching = matchingRepository.findTopBySeniorIdAndMatchingStatus(senior.getId(), MatchingStatus.ACTIVE).get();
+
+        // 봉사 기간 조회
+        Schedule schedule = scheduleRepository.findByMatching(matching).get();
+
+        // 응답
+        GetSeniorManagePageResponse.SeniorProfile seniorProfile = new GetSeniorManagePageResponse.SeniorProfile(senior.getName(),
+                LocalDateTimeUtil.toFormattedString(senior.getBirthday()),
+                senior.getPhone(),
+                LocalDateTimeUtil.toFormattedString(schedule.getStartDate()),
+                LocalDateTimeUtil.toFormattedString(schedule.getEndDate())
+        );
+
+        // 봉사자도 찾고
+        GetSeniorManagePageResponse.MatchedVolunteer matchedVolunteer = null;
+        Volunteer volunteer = matching.getVolunteer();
+        if(volunteer != null){
+            Optional<VolunteerRecord> optRecord = volunteerRecordRepository.findTopByMatchingOrderByIdDesc(matching);
+            String lastWorkDate = optRecord.map(record -> LocalDateTimeUtil.toFormattedString(record.getScheduledDate())).orElse(null);
+            matchedVolunteer =  new GetSeniorManagePageResponse.MatchedVolunteer(volunteer.getName(),lastWorkDate );
+        }
+
+        return new GetSeniorManagePageResponse(seniorProfile, senior.getCode(), matchedVolunteer);
     }
 }

--- a/src/main/java/org/example/backend/domain/organization/service/GetOrgSeniorsService.java
+++ b/src/main/java/org/example/backend/domain/organization/service/GetOrgSeniorsService.java
@@ -1,0 +1,42 @@
+package org.example.backend.domain.organization.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.backend.domain.matching.model.Matching;
+import org.example.backend.domain.matching.repository.MatchingRepository;
+import org.example.backend.domain.organization.dto.GetOrgSeniorsResponse;
+import org.example.backend.domain.organization.model.Organization;
+import org.example.backend.domain.organization.repository.OrganizationRepository;
+import org.example.backend.domain.senior.model.Senior;
+import org.example.backend.domain.senior.repository.SeniorRepository;
+import org.example.backend.global.common.exception.CustomException;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.example.backend.global.common.response.status.BaseExceptionResponseStatus.ENTITY_NOT_FOUND;
+
+@RequiredArgsConstructor
+@Service
+public class GetOrgSeniorsService {
+    private final OrganizationRepository organizationRepository;
+    private final SeniorRepository seniorRepository;
+    private final MatchingRepository matchingRepository;
+    public GetOrgSeniorsResponse getSeniors(Long orgUserId) {
+        // 기관 조회
+        Organization organization = organizationRepository.findByUserId(orgUserId).orElseThrow(() -> new CustomException(ENTITY_NOT_FOUND));
+
+        // 시니어들을 조회
+        List<Senior> seniors = seniorRepository.findAllByOrganization(organization);
+
+        // 응답 생성
+        List<GetOrgSeniorsResponse.SeniorDto> collect = seniors.stream().map(senior -> {
+            Matching lastMatching = matchingRepository.findTopBySeniorOrderByIdDesc(senior).get();
+            GetOrgSeniorsResponse.SeniorDto seniorDto = GetOrgSeniorsResponse.SeniorDto.entityToDto(senior, lastMatching.getMatchingStatus());
+            return seniorDto;
+        }).collect(Collectors.toList());
+
+        return new GetOrgSeniorsResponse(collect);
+    }
+}

--- a/src/main/java/org/example/backend/domain/record/repository/VolunteerRecordRepository.java
+++ b/src/main/java/org/example/backend/domain/record/repository/VolunteerRecordRepository.java
@@ -52,4 +52,6 @@ public interface VolunteerRecordRepository extends JpaRepository<VolunteerRecord
     // 특정 매칭 + 오늘 날짜에 해당하는 VolunteerRecord 조회
     Optional<VolunteerRecord> findByMatchingAndScheduledDate(Matching matching, LocalDate scheduledDate);
 
+    Optional<VolunteerRecord> findTopByMatchingOrderByIdDesc(Matching matching);
+
 }

--- a/src/main/java/org/example/backend/domain/senior/service/OrganizationSeniorService.java
+++ b/src/main/java/org/example/backend/domain/senior/service/OrganizationSeniorService.java
@@ -43,7 +43,7 @@ public class OrganizationSeniorService {
         }
 
         // 현재 존재하는 매칭 조회
-        Matching matching = matchingRepository.findBySeniorIdAndMatchingStatus(seniorId, MatchingStatus.ACTIVE).orElseThrow(() -> new CustomException(ENTITY_NOT_FOUND));
+        Matching matching = matchingRepository.findTopBySeniorIdAndMatchingStatus(seniorId, MatchingStatus.ACTIVE).orElseThrow(() -> new CustomException(ENTITY_NOT_FOUND));
 
         String seniorName = matching.getSenior().getName();
         String volunteerName = matching.getVolunteer().getName();

--- a/src/main/java/org/example/backend/global/util/AgeUtils.java
+++ b/src/main/java/org/example/backend/global/util/AgeUtils.java
@@ -1,0 +1,29 @@
+package org.example.backend.global.util;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.Period;
+import java.time.ZoneId;
+import java.util.Objects;
+
+public final class AgeUtils {
+    private static final ZoneId KOREA = ZoneId.of("Asia/Seoul");
+    private static final Clock CLOCK = Clock.system(KOREA);
+
+    private AgeUtils() {}
+
+    /** 오늘(Asia/Seoul 기준) 기준 만 나이 */
+    public static int toAge(LocalDate birthDate) {
+        return toAge(birthDate, LocalDate.now(CLOCK));
+    }
+
+    /** 기준일(onDate) 기준 만 나이 */
+    public static int toAge(LocalDate birthDate, LocalDate onDate) {
+        Objects.requireNonNull(birthDate, "birthDate must not be null");
+        Objects.requireNonNull(onDate, "onDate must not be null");
+        if (birthDate.isAfter(onDate)) {
+            throw new IllegalArgumentException("birthDate cannot be in the future");
+        }
+        return Period.between(birthDate, onDate).getYears();
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈

#37

## ✨ 구현 내용
<!-- 구현한 코드에 대한 설명을 적어주세요 -->

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 조직 계정용 어르신 목록 조회 추가: 이름, 나이, 코드, 매칭 상태를 한눈에 확인.
  * 조직 계정용 어르신 관리 페이지 조회 추가: 프로필(이름, 생일, 연락처, 서비스 시작/종료), 어르신 코드, 현재 매칭된 봉사자와 최근 활동일 제공.
  * 나이 계산 유틸리티 추가: 생년월일로 정확한 연령 표시 지원.
* 리팩터링
  * 최신 매칭/활동 기록을 우선해 정보가 보다 일관되고 최신 상태로 표시되도록 정비.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->